### PR TITLE
修复在专项答题过程中查找元素按钮失败抛出异常的问题（重新遍历页面元素）

### DIFF
--- a/SourcePackages/pdlearn/answer_question.py
+++ b/SourcePackages/pdlearn/answer_question.py
@@ -66,7 +66,11 @@ def answer_question(quiz_type, cookies, scores, score_all, quiz_xpath, category_
             driver_ans.click_xpath(quiz_xpath)  # 点击各个题目的去答题按钮
             time.sleep(2)
             if quiz_type != "daily":  # 如果是每日答题就不用找available了
-                to_click = find_available_quiz(quiz_type, driver_ans, uid)
+                # 此处修改是因为页面可能刷新后导致的查找元素button 丢失从而引发异常重新此处用可以重新查找来解决
+                try:
+                    to_click = find_available_quiz(quiz_type, driver_ans, uid)
+                except Exception as e:
+                    to_click = find_available_quiz(quiz_type, driver_ans, uid)
                 if to_click is not None:
                     to_click.click()
                     time.sleep(0.5)


### PR DESCRIPTION
<!--
感谢你的支持，接下来请填写下方内容，以确保贡献尽快被通过：
-->
## 清单
<!--
在适用的框中以 x 替换空格来勾选。您也可以在创建PR后填写这些内容。如果您不确定其中的任何一个，请随时询问。我们在这里为您提供帮助！
-->

- [x] 我已经仔细阅读了所有文档的说明
- [x] 我确认我是以最新版 dev 分支代码为基础编写这个 PR
- [x] 我确认我这个 PR 仅向 dev 分支提交贡献
- [x] 我在本地测试过了全部代码

## 说明：

